### PR TITLE
Use custom bind names

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,8 +2,8 @@ java_binary(
     name = "jarjar_runner",
     main_class = "org.pantsbuild.jarjar.Main",
     runtime_deps = [
-        "@org_pantsbuild_jarjar//jar",
-        "@org_ow2_asm_asm//jar",
-        "@org_ow2_asm_asm_commons//jar",
+        "//external:com_github_johnynek_bazel_jar_jar/jarjar",
+        "//external:com_github_johnynek_bazel_jar_jar/asm",
+        "//external:com_github_johnynek_bazel_jar_jar/asm_commons",
         ],
     visibility = ["//visibility:public"])

--- a/jar_jar.bzl
+++ b/jar_jar.bzl
@@ -19,25 +19,34 @@ jar_jar = rule(
     })
 
 def _mvn_name(coord):
-  nocolon = "_".join(coord.split(":")[0:-1])
+  nocolon = "_".join(coord.split(":"))
   nodot = "_".join(nocolon.split("."))
   nodash = "_".join(nodot.split("-"))
   return nodash
 
-def mvn_jar(coord, sha):
+def _mvn_jar(coord, sha, bname, serv):
+  nm = _mvn_name(coord)
   native.maven_jar(
-    name = _mvn_name(coord),
+    name = nm,
     artifact = coord,
-    sha1 = sha
+    sha1 = sha,
+    server = serv
   )
+  native.bind(name=("com_github_johnynek_bazel_jar_jar/%s" % bname), actual = "@%s//jar" % nm)
 
-def jar_jar_repositories():
-  mvn_jar(
+def jar_jar_repositories(server=None):
+  _mvn_jar(
     "org.pantsbuild:jarjar:1.6.3",
-    "cf54d4b142f5409c394095181c8d308a81869622")
-  mvn_jar(
+    "cf54d4b142f5409c394095181c8d308a81869622",
+    "jarjar",
+    server)
+  _mvn_jar(
     "org.ow2.asm:asm:5.0.4",
-    "0da08b8cce7bbf903602a25a3a163ae252435795")
-  mvn_jar(
+    "0da08b8cce7bbf903602a25a3a163ae252435795",
+    "asm",
+    server)
+  _mvn_jar(
     "org.ow2.asm:asm-commons:5.0.4",
-    "5a556786086c23cd689a0328f8519db93821c04c")
+    "5a556786086c23cd689a0328f8519db93821c04c",
+    "asm_commons",
+    server)


### PR DESCRIPTION
jarjar wants asm 5, but our repos need asm4. Since we don't run jarjar except as a tool, that's okay, but we need a custom way to refer to it.