### PR TITLE
Provide JavaInfo so jarjar targets can be a dep of scala targets.

### DIFF
--- a/jar_jar.bzl
+++ b/jar_jar.bzl
@@ -7,6 +7,11 @@ def _jar_jar_impl(ctx):
     progress_message="jarjar %s" % ctx.label,
     arguments=["process", ctx.file.rules.path, ctx.file.input_jar.path, ctx.outputs.jar.path])
 
+  return JavaInfo(
+      output_jar = ctx.outputs.jar,
+      compile_jar = ctx.outputs.jar
+  )
+
 jar_jar = rule(
     implementation = _jar_jar_impl,
     attrs = {
@@ -16,7 +21,8 @@ jar_jar = rule(
     },
     outputs = {
       "jar": "%{name}.jar"
-    })
+    },
+    provides = [JavaInfo])
 
 def _mvn_name(coord):
   nocolon = "_".join(coord.split(":"))


### PR DESCRIPTION
Recent versions of rules_scala require that dependencies return JavaInfo: https://github.com/bazelbuild/rules_scala/pull/523/files#diff-3830e6e26d863974d38e511b04761916R36

This adds a `JavaInfo` to jar_jar rule so scala targets can depend on them.