### PR TITLE
Add usage guidance to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@ This rule uses [pantsbuild's jarjar fork](https://github.com/pantsbuild/jarjar).
 The main use case is to use more than one version of a jar at a time with different versions mapped to a different package. It can also be used to do [*dependency shading*](https://softwareengineering.stackexchange.com/questions/297276/what-is-a-shaded-java-dependency).
 
 
+## How to add to Bazel `WORKSPACE`
+
+```
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "com_github_johnynek_bazel_jar_jar",
+    commit = "16e48f319048e090a2fe7fd39a794312d191fc6f", # Latest commit SHA as at 2019/02/13
+    remote = "git://github.com/johnynek/bazel_jar_jar.git",
+)
+
+load(
+    "@com_github_johnynek_bazel_jar_jar//:jar_jar.bzl",
+    "jar_jar_repositories",
+)
+jar_jar_repositories()
+```
+
+
 ## Usage
 
 _Note_: Example code exists in [`test/example`](/test/example)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,32 @@
 # bazel_jar_jar
+
 JarJar rules for bazel (rename packages and classes in existing jars)
 
 This rule uses [pantsbuild's jarjar fork](https://github.com/pantsbuild/jarjar).
-The main use case is to use more than one version of a jar at a time with different versions mapped to
-a different package.
+The main use case is to use more than one version of a jar at a time with different versions mapped to a different package. It can also be used to do [*dependency shading*](https://softwareengineering.stackexchange.com/questions/297276/what-is-a-shaded-java-dependency).
 
-As an example, see the test/example.
+
+## Usage
+
+_Note_: Example code exists in [`test/example`](/test/example)
+
+Specify a rule in a file that will remap one package path into another:
+
+```
+rule com.twitter.scalding.** foo.@1
+```
+
+Put that file in the same directory as the Bazel `BUILD` file that will specify the `jar_jar` rules. Reference that file in the `rules` field of the `jar_jar` rule
+
+```
+jar_jar(
+    name = "shaded_args",
+    input_jar = "@com_twitter_scalding_args//jar",
+    rules = "<FILENAME>"
+)
+```
+
+The `input_jar` specifies the package that will be relocated. `name` is the target label to be used in place of the original package target.
+
+
+Change any references in your code to the original package path to the new shaded package path. For example: `import com.twitter.scalding.Args` becomes `import foo.Args`.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Specify a rule in a file that will remap one package path into another:
 rule com.twitter.scalding.** foo.@1
 ```
 
-Put that file in the same directory as the Bazel `BUILD` file that will specify the `jar_jar` rules. Reference that file in the `rules` field of the `jar_jar` rule
+Put that file in the same directory as the Bazel `BUILD` file that will specify the `jar_jar` rules. Reference that file in the `rules` field of the `jar_jar` rule.
 
 ```
 jar_jar(
@@ -26,7 +26,7 @@ jar_jar(
 )
 ```
 
-The `input_jar` specifies the package that will be relocated. `name` is the target label to be used in place of the original package target.
+The `input_jar` specifies the package that will be relocated. `name` is the target label to be used in place of the original package target label.
 
 
-Change any references in your code to the original package path to the new shaded package path. For example: `import com.twitter.scalding.Args` becomes `import foo.Args`.
+Change any references in your code from the original package path to the new shaded package path. For example: `import com.twitter.scalding.Args` becomes `import foo.Args`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bazel_jar_jar
 
-JarJar rules for bazel (rename packages and classes in existing jars)
+JarJar rules for [Bazel](https://bazel.build/) (rename packages and classes in existing jars)
 
 This rule uses [pantsbuild's jarjar fork](https://github.com/pantsbuild/jarjar).
 The main use case is to use more than one version of a jar at a time with different versions mapped to a different package. It can also be used to do [*dependency shading*](https://softwareengineering.stackexchange.com/questions/297276/what-is-a-shaded-java-dependency).


### PR DESCRIPTION
This project was quite helpful in supporting dependency shading in Bazel, but when first arriving at the repo the README seemed quite unapproachable and unloved. 

I've attempted to add usage instruction right on the `README.md` that are hopefully accurate and useful but they're just what I produced from having used this Bazel rule and figuring out how it worked.

There's still a couple of things that I think are unclear. 

* `rule com.twitter.scalding.** foo.@1` this syntax is undocumented. Can you do `scalding.*` or `@2`, instead of what's shown in example? 
* `jar_jar.rules` is plural, but it accepts a string. Can it also accept a list? It would be nice if this info was front and centre.

If I look into the source I could submit an update to this PR that adds more detail. 

