### PR TITLE
Use ctx.actions.run

### DIFF
--- a/jar_jar.bzl
+++ b/jar_jar.bzl
@@ -5,7 +5,7 @@ load(
 )
 
 def _jar_jar_impl(ctx):
-  ctx.action(
+  ctx.actions.run(
     inputs=[ctx.file.rules, ctx.file.input_jar],
     outputs=[ctx.outputs.jar],
     executable=ctx.executable._jarjar_runner,


### PR DESCRIPTION
Handles bazel 0.27 error message:
```
File "/private/var/tmp/_bazel_shacharan/8c22eb77db72f764bcc6d118ac354c04/external/com_github_johnynek_bazel_jar_jar/jar_jar.bzl", line 8, in _jar_jar_impl
		ctx.action(inputs = [ctx.file.rules, ctx.fi...], <4 more arguments>)
Use ctx.actions.run or ctx.actions.run_shell instead of ctx.action.
```