### PR TITLE
Prefix name for jvm_maven_import_external with "jar_jar_" to avoid name collisions

### DIFF
--- a/jar_jar.bzl
+++ b/jar_jar.bzl
@@ -39,7 +39,7 @@ def _mvn_name(coord):
   return nodash
 
 def _mvn_jar(coord, sha, bname, servers):
-  nm = _mvn_name(coord)
+  nm = "jar_jar_" + _mvn_name(coord)
   jvm_maven_import_external(
       name=nm,
       artifact=coord,


### PR DESCRIPTION
Such collisions may appear when jar_jar's dependencies are also included
by other plugins, like rules_jvm_external.
The generated structure for those dependencies included with those plugins
may be different than expected by us and it can cause build errors
(e.g. BUILD file not found).

Prefix the name for jvm_maven_import_external with "jar_jar_", so that no
collisions occur.