### PR TITLE
Fix git:// URL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "com_github_johnynek_bazel_jar_jar",
     commit = "16e48f319048e090a2fe7fd39a794312d191fc6f", # Latest commit SHA as at 2019/02/13
-    remote = "git://github.com/johnynek/bazel_jar_jar.git",
+    remote = "https://github.com/johnynek/bazel_jar_jar.git",
 )
 
 load(


### PR DESCRIPTION
[As of March 15th, 2022, github disabled the old git:// URL access.](https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git)

Git pulls using git:// no longer function, and this example in the readme is outdated. The https:// protocol can be used as a replacement with no changes.