### PR TITLE
Make available inline rules directly in the jar_jar rule.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,17 @@ jar_jar(
 
 The `input_jar` specifies the package that will be relocated. `name` is the target label to be used in place of the original package target label.
 
+Alternately, if you don't want to put the rules in a file, you can put the shading rules inline directly in the rule.  These follow the same
+[rules file formatting](#rules-file-formatting) as below, with each entry in the array acting as a line in the file.
+```
+jar_jar(
+    name = "shaded_args",
+    input_jar = "@com_twitter_scalding_args//jar",
+    inline_rules = ["rule com.twitter.scalding.** foo.@1"]
+```
+`inline_rules` and `rules` referring to a file are exclusive options; you can only have one or the other in your rule.  You must have one of them.
 
-Change any references in your code from the original package path to the new shaded package path. For example: `import com.twitter.scalding.Args` becomes `import foo.Args`.
+Make sure to change any references in your code from the original package path to the new shaded package path. For example: `import com.twitter.scalding.Args` becomes `import foo.Args`.
 
 ## Rules File Formatting
 

--- a/jar_jar.bzl
+++ b/jar_jar.bzl
@@ -5,6 +5,8 @@ load(
 
 def _jar_jar_impl(ctx):
     rule_file = ctx.file.rules
+    if rule_file != None and ctx.attr.inline_rules != []:
+        fail("rules= and inline_rules= are incompatible; use one or the other.")
     if rule_file == None:
         rule_file = ctx.actions.declare_file("jar_jar-rules-" + ctx.label.name + ".tmp")
         ctx.actions.write(

--- a/jar_jar.bzl
+++ b/jar_jar.bzl
@@ -6,7 +6,9 @@ load(
 def _jar_jar_impl(ctx):
     rule_file = ctx.file.rules
     if rule_file != None and ctx.attr.inline_rules != []:
-        fail("rules= and inline_rules= are incompatible; use one or the other.")
+        fail("Using both a rules file and inline_rules are incompatible; use one or the other.")
+    if rule_file == None and ctx.attr.inline_rules == []:
+        fail("You have to specify either a rules file or inline_rules.")
     if rule_file == None:
         rule_file = ctx.actions.declare_file("jar_jar-rules-" + ctx.label.name + ".tmp")
         ctx.actions.write(

--- a/jar_jar.bzl
+++ b/jar_jar.bzl
@@ -6,7 +6,7 @@ load(
 def _jar_jar_impl(ctx):
     rule_file = ctx.file.rules
     if rule_file == None:
-        rule_file = ctx.actions.declare_file("tmp-rules-" + ctx.label.name)
+        rule_file = ctx.actions.declare_file("jar_jar-rules-" + ctx.label.name + ".tmp")
         ctx.actions.write(
             output = rule_file,
             content = "\n".join(ctx.attr.inline_rules)

--- a/jar_jar.bzl
+++ b/jar_jar.bzl
@@ -4,12 +4,20 @@ load(
 )
 
 def _jar_jar_impl(ctx):
+    rule_file = ctx.file.rules
+    if rule_file == None:
+        rule_file = ctx.actions.declare_file("tmp-rules-" + ctx.label.name)
+        ctx.actions.write(
+            output = rule_file,
+            content = "\n".join(ctx.attr.inline_rules)
+        )
+
     ctx.actions.run(
-        inputs = [ctx.file.rules, ctx.file.input_jar],
+        inputs = [rule_file, ctx.file.input_jar],
         outputs = [ctx.outputs.jar],
         executable = ctx.executable._jarjar_runner,
         progress_message = "jarjar %s" % ctx.label,
-        arguments = ["process", ctx.file.rules.path, ctx.file.input_jar.path, ctx.outputs.jar.path],
+        arguments = ["process", rule_file.path, ctx.file.input_jar.path, ctx.outputs.jar.path],
     )
 
     return [
@@ -25,6 +33,7 @@ jar_jar = rule(
     attrs = {
         "input_jar": attr.label(allow_single_file = True),
         "rules": attr.label(allow_single_file = True),
+        "inline_rules" : attr.string_list(),
         "_jarjar_runner": attr.label(executable = True, cfg = "host", default = Label("@com_github_johnynek_bazel_jar_jar//src/main/java/com/github/johnynek/jarjar:app")),
     },
     outputs = {

--- a/test/inline_example/BUILD
+++ b/test/inline_example/BUILD
@@ -1,0 +1,21 @@
+load(
+    "@com_github_johnynek_bazel_jar_jar//:jar_jar.bzl",
+    "jar_jar",
+)
+
+jar_jar(
+    name = "shaded_args",
+    input_jar = "@com_twitter_scalding_args//jar",
+    inline_rules = ["rule com.twitter.scalding.** foo.@1"],
+)
+
+java_import(
+    name = "shaded_scalding",
+    jars = ["shaded_args.jar"],
+)
+
+java_library(
+    name = "use_foo",
+    srcs = ["UseFoo.java"],
+    deps = [":shaded_scalding"],
+)

--- a/test/inline_example/UseFoo.java
+++ b/test/inline_example/UseFoo.java
@@ -1,0 +1,7 @@
+package FooTown;
+
+import foo.Args;
+
+class Bar {
+  public Bar(Args a) { }
+}


### PR DESCRIPTION
This allows us to put the rule in the BUILD instead of having a separate file for the rules.  This creates the file to hold the filtering rule in the sandbox, instead of in the source tree.

This is particularly useful when calling `jar_jar` from a macro, when you don't want to dynamically create files in the source tree to hold a temporarily created rule file.