### PR TITLE
Modernize Bazel setup

### DIFF
--- a/jar_jar_toolchain.bzl
+++ b/jar_jar_toolchain.bzl
@@ -12,7 +12,7 @@ jar_jar_toolchain = rule(
     attrs = {
         "rules": attr.label(allow_single_file = True),
         "duplicate_class_to_warn": attr.bool(mandatory = False, default = False),
-        "jar_jar_runner": attr.label(executable = True, cfg = "host", default = Label("@com_github_johnynek_bazel_jar_jar//src/main/java/com/github/johnynek/jarjar:app")),
+        "jar_jar_runner": attr.label(executable = True, cfg = "exec", default = "//src/main/java/com/github/johnynek/jarjar:app"),
         "jar_jar_is_native_image": attr.bool(default = False)
     },
 )

--- a/src/main/java/com/github/johnynek/jarjar/BUILD
+++ b/src/main/java/com/github/johnynek/jarjar/BUILD
@@ -6,8 +6,8 @@ java_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//external:com_github_johnynek_bazel_jar_jar/asm",
-        "//external:com_github_johnynek_bazel_jar_jar/asm_commons",
+        "@bazel_jar_jar_asm//jar",
+        "@bazel_jar_jar_asm_commons//jar",
     ],
 )
 


### PR DESCRIPTION
* No longer rely on `native.bind` and the `external` package
* Replace host with exec cfg
* Use `ctx.actions.args()` instead of string lists
* Use `http_jar` instead of `jvm_maven_import_external`