### PR TITLE
Use attr.output instead of deprecated outputs dict 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ jar_jar(
 ```
 
 The `input_jar` specifies the package that will be relocated. `name` is the target label to be used in place of the original package target label.
+The optional `output_jar` field specifies the name of the output jar. If not specified, the output jar will be named `<name>.jar`.
 
 Alternately, if you don't want to put the rules in a file, you can put the shading rules inline directly in the rule.  These follow the same
 [rules file formatting](#rules-file-formatting) as below, with each entry in the array acting as a line in the file.

--- a/internal/jar_jar.bzl
+++ b/internal/jar_jar.bzl
@@ -1,0 +1,46 @@
+def _jar_jar_impl(ctx):
+    rule_file = ctx.file.rules
+    if rule_file != None and ctx.attr.inline_rules != []:
+        fail("Using both a rules file and inline_rules are incompatible; use one or the other.")
+    if rule_file == None and ctx.attr.inline_rules == []:
+        fail("You have to specify either a rules file or inline_rules.")
+    if rule_file == None:
+        rule_file = ctx.actions.declare_file("jar_jar-rules-" + ctx.label.name + ".tmp")
+        ctx.actions.write(
+            output = rule_file,
+            content = "\n".join(ctx.attr.inline_rules)
+        )
+
+    args = ctx.actions.args()
+    args.add("process")
+    args.add(rule_file)
+    args.add(ctx.file.input_jar)
+    args.add(ctx.outputs.output_jar)
+
+    ctx.actions.run(
+        inputs = [rule_file, ctx.file.input_jar],
+        outputs = [ctx.outputs.output_jar],
+        executable = ctx.executable._jarjar_runner,
+        progress_message = "jarjar %s" % ctx.label,
+        arguments = [args],
+    )
+
+    return [
+        JavaInfo(
+            output_jar = ctx.outputs.output_jar,
+            compile_jar = ctx.outputs.output_jar,
+        ),
+        DefaultInfo(files = depset([ctx.outputs.output_jar])),
+    ]
+
+jar_jar = rule(
+    implementation = _jar_jar_impl,
+    attrs = {
+        "output_jar": attr.output(mandatory = True),
+        "input_jar": attr.label(allow_single_file = True),
+        "rules": attr.label(allow_single_file = True),
+        "inline_rules" : attr.string_list(),
+        "_jarjar_runner": attr.label(executable = True, cfg = "exec", default = "//src/main/java/com/github/johnynek/jarjar:app"),
+    },
+    provides = [JavaInfo],
+)

--- a/jar_jar.bzl
+++ b/jar_jar.bzl
@@ -2,55 +2,17 @@ load(
     "@bazel_tools//tools/build_defs/repo:http.bzl",
     "http_jar",
 )
-
-def _jar_jar_impl(ctx):
-    rule_file = ctx.file.rules
-    if rule_file != None and ctx.attr.inline_rules != []:
-        fail("Using both a rules file and inline_rules are incompatible; use one or the other.")
-    if rule_file == None and ctx.attr.inline_rules == []:
-        fail("You have to specify either a rules file or inline_rules.")
-    if rule_file == None:
-        rule_file = ctx.actions.declare_file("jar_jar-rules-" + ctx.label.name + ".tmp")
-        ctx.actions.write(
-            output = rule_file,
-            content = "\n".join(ctx.attr.inline_rules)
-        )
-
-    args = ctx.actions.args()
-    args.add("process")
-    args.add(rule_file)
-    args.add(ctx.file.input_jar)
-    args.add(ctx.outputs.jar)
-
-    ctx.actions.run(
-        inputs = [rule_file, ctx.file.input_jar],
-        outputs = [ctx.outputs.jar],
-        executable = ctx.executable._jarjar_runner,
-        progress_message = "jarjar %s" % ctx.label,
-        arguments = [args],
-    )
-
-    return [
-        JavaInfo(
-            output_jar = ctx.outputs.jar,
-            compile_jar = ctx.outputs.jar,
-        ),
-        DefaultInfo(files = depset([ctx.outputs.jar])),
-    ]
-
-jar_jar = rule(
-    implementation = _jar_jar_impl,
-    attrs = {
-        "input_jar": attr.label(allow_single_file = True),
-        "rules": attr.label(allow_single_file = True),
-        "inline_rules" : attr.string_list(),
-        "_jarjar_runner": attr.label(executable = True, cfg = "exec", default = "//src/main/java/com/github/johnynek/jarjar:app"),
-    },
-    outputs = {
-        "jar": "%{name}.jar",
-    },
-    provides = [JavaInfo],
+load(
+    "//internal:jar_jar.bzl",
+    _jar_jar = "jar_jar",
 )
+
+def jar_jar(name, output_jar = None, **kwargs):
+    _jar_jar(
+        name = name,
+        output_jar = output_jar or (name + ".jar"),
+        **kwargs
+    )
 
 def _http_jar_with_servers(name, path, sha256, servers):
     http_jar(

--- a/test/example/BUILD
+++ b/test/example/BUILD
@@ -3,6 +3,23 @@ load(
     "jar_jar",
 )
 
+alias(
+    name = "file_output",
+    actual = "shaded_args.jar",
+)
+
+alias(
+    name = "custom_file_output",
+    actual = "custom_name.jar",
+)
+
+jar_jar(
+    name = "shaded_args_custom_out",
+    input_jar = "@com_twitter_scalding_args//jar",
+    rules = "shade_rule",
+    output_jar = "custom_name.jar",
+)
+
 jar_jar(
     name = "shaded_args",
     input_jar = "@com_twitter_scalding_args//jar",


### PR DESCRIPTION
Backwards compatibility is preserved by wrapping the `jar_jar` rule in a
macro that populates the new `output_jar` attribute if the user doesn't
set it. The output of a `jar_jar` target can still be referenced as a
file target as demonstrated by new tests.

In addition, user can now provide a custom name for the output jar.