### PR TITLE
Add support for multi-release jars

### DIFF
--- a/src/main/java/com/github/johnynek/jarjar/misplaced/MisplacedClassProcessor.java
+++ b/src/main/java/com/github/johnynek/jarjar/misplaced/MisplacedClassProcessor.java
@@ -44,7 +44,7 @@ public abstract class MisplacedClassProcessor implements JarProcessor {
       struct.skipTransform = true;
       return true;
     }
-    if (!originalClassName.equals(struct.name)) {
+    if (!originalClassName.equals(struct.getClassName())) {
       System.err.println(formatMisplacedClassMessage(struct, originalClassName));
       handleMisplacedClass(struct, originalClassName);
       if (!shouldTransform()) {

--- a/src/main/java/com/github/johnynek/jarjar/util/EntryStruct.java
+++ b/src/main/java/com/github/johnynek/jarjar/util/EntryStruct.java
@@ -16,9 +16,30 @@
 
 package com.github.johnynek.jarjar.util;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class EntryStruct {
+    private static final Pattern NAME_PARTS_PATTERN = Pattern.compile("((?:META-INF/versions/[1-9][0-9]*/)?)(.*)");
+
     public byte[] data;
     public String name;
     public long time;
     public boolean skipTransform;
+
+    /**
+     * Returns a version path prefix such as "META-INF/versions/9/" if the entry is a versioned
+     * entry in a multi-release JAR, or an empty string otherise.
+     */
+    public String getVersionPrefix() {
+        Matcher matcher = NAME_PARTS_PATTERN.matcher(name);
+        matcher.matches();
+        return matcher.group(1);
+    }
+
+    public String getClassName() {
+        Matcher matcher = NAME_PARTS_PATTERN.matcher(name);
+        matcher.matches();
+        return matcher.group(2);
+    }
 }

--- a/src/main/java/com/github/johnynek/jarjar/util/JarTransformer.java
+++ b/src/main/java/com/github/johnynek/jarjar/util/JarTransformer.java
@@ -41,7 +41,7 @@ abstract public class JarTransformer implements JarProcessor {
                 throw new IOException("Unable to transform " + struct.name, e);
             }
             struct.data = w.toByteArray();
-            struct.name = pathFromName(w.getClassName());
+            struct.name = struct.getVersionPrefix() + pathFromName(w.getClassName());
         }
         return true;
     }


### PR DESCRIPTION
Versioned classes are shaded based on their class name rather than their full path, which includes a version prefix that must be preserved.

All other processors still apply to the full jar entry path.