### PR TITLE
Add explicit `java_binary` load in BUILD.bazel

### DIFF
--- a/src/main/java/com/github/johnynek/jarjar/BUILD.bazel
+++ b/src/main/java/com/github/johnynek/jarjar/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_java//java:defs.bzl", "java_binary")
 java_binary(
     name = "app",
     main_class = "com.github.johnynek.jarjar.Main",
-    srcs = ["Main.java"], 
+    srcs = ["Main.java"],
     visibility = ["//visibility:public"],
     deps = ["@jvm__jarjar_abrams_assembly//jar"],
 )


### PR DESCRIPTION
Bazel 8+ extracted Java rules into the external rules_java repository. As a result, java_binary and other Java rule symbols are not auto-loaded in BUILD files.