### PR TITLE
Import JavaInfo from rules_java

### DIFF
--- a/internal/jar_jar.bzl
+++ b/internal/jar_jar.bzl
@@ -1,4 +1,5 @@
 load("@bazel_tools//tools/jdk:toolchain_utils.bzl", "find_java_toolchain")
+load("@rules_java//java:defs.bzl", "JavaInfo")
 load("@rules_java//java/common:java_common.bzl", "java_common")
 
 def _jar_jar_impl(ctx):

--- a/jar_jar_aspect.bzl
+++ b/jar_jar_aspect.bzl
@@ -1,4 +1,4 @@
-load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+load("@rules_java//java:defs.bzl", "JavaInfo")
 
 # This is the provider we pass up along to the outer thin_jar_jar rule.
 ShadedJars = provider(fields = [

--- a/jar_jar_aspect.bzl
+++ b/jar_jar_aspect.bzl
@@ -1,3 +1,5 @@
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+
 # This is the provider we pass up along to the outer thin_jar_jar rule.
 ShadedJars = provider(fields = [
     "java_info",

--- a/thin_jar_jar.bzl
+++ b/thin_jar_jar.bzl
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "JavaInfo")
 load("//:jar_jar_aspect.bzl", "ShadedJars", "jar_jar_aspect", "merge_shaded_jars_info")
 
 def _thin_jar_jar_impl(ctx):


### PR DESCRIPTION
As of Bazel 9, JavaInfo is no longer available natively, and requires an import.